### PR TITLE
Isolate template settings from other modules

### DIFF
--- a/lib/templates/banner.js
+++ b/lib/templates/banner.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var _ = require('lodash');
+var _ = require('lodash').runInContext();
 _.templateSettings.interpolate = /{{([\s\S]+?)}}/g;
 
 module.exports = function() {


### PR DESCRIPTION
Now `_.templateSettings.interpolate` changes this setting for all modules that use same lodash.
Since `npm@v3` that means that _ALL_ modules get this option and it breaks them. For example I can't build [angular-strap](https://github.com/mgcrea/angular-strap) with npm3 now.

This change is a recommended way to isolate settings from other modules. See https://github.com/lodash/lodash/issues/705
